### PR TITLE
Fixed Image not defined when using jsdom

### DIFF
--- a/src/react-konva.js
+++ b/src/react-konva.js
@@ -221,6 +221,7 @@ var NodeMixin = {
       var val, prop;
       for(prop in updatedProps) {
         val = updatedProps[prop];
+	var Image = Image || window.Image;
         if (val instanceof Image && !val.complete) {
           var node = this.node;
           val.addEventListener('load', function() {


### PR DESCRIPTION
Weakened the dependency for Image to be defined on the global scope by additionally checking window.Image.